### PR TITLE
Rename package to mcp-claude-desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Claude Desktop MCP
+# MCP Claude Desktop
 
 A Model Context Protocol (MCP) server that enables Claude Code to communicate with Claude Desktop. This server allows Claude Code to send prompts to Claude Desktop and poll for responses.
 
@@ -25,7 +25,7 @@ The simplest way to use this server is directly with npx, without any installati
   "mcpServers": {
     "claude-desktop": {
       "command": "npx",
-      "args": ["claude-desktop-mcp"]
+      "args": ["mcp-claude-desktop"]
     }
   }
 }
@@ -35,8 +35,8 @@ The simplest way to use this server is directly with npx, without any installati
 
 1. Clone this repository:
 ```bash
-git clone https://github.com/dpaluy/claude-desktop-mcp
-cd claude-desktop-mcp
+git clone https://github.com/dpaluy/mcp-claude-desktop
+cd mcp-claude-desktop
 ```
 
 2. Install dependencies:
@@ -56,7 +56,7 @@ npm run build
   "mcpServers": {
     "claude-desktop": {
       "command": "node",
-      "args": ["/path/to/claude-desktop-mcp/dist/index.js"]
+      "args": ["/path/to/mcp-claude-desktop/dist/index.js"]
     }
   }
 }
@@ -218,15 +218,15 @@ The MCP server uses AppleScript to communicate with Claude Desktop:
 
 ## Contributing
 
-We welcome contributions to Claude Desktop MCP! Whether you're fixing bugs, adding features, or improving documentation, your help is appreciated.
+We welcome contributions to MCP Claude Desktop! Whether you're fixing bugs, adding features, or improving documentation, your help is appreciated.
 
 ### Getting Started
 
 1. Fork the repository
 2. Clone your fork:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/claude-desktop-mcp
-   cd claude-desktop-mcp
+   git clone https://github.com/YOUR_USERNAME/mcp-claude-desktop
+   cd mcp-claude-desktop
    ```
 3. Install dependencies:
    ```bash

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "claude-desktop-mcp",
+  "name": "mcp-claude-desktop",
   "version": "1.0.0",
   "description": "Model Context Protocol (MCP) tool to interact with Claude Desktop on macOS",
   "main": "dist/index.js",
   "type": "module",
   "bin": {
-    "claude-desktop-mcp": "dist/index.js"
+    "mcp-claude-desktop": "dist/index.js"
   },
   "files": [
     "dist",
@@ -32,12 +32,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dpaluy/claude-desktop-mcp.git"
+    "url": "git+https://github.com/dpaluy/mcp-claude-desktop.git"
   },
   "bugs": {
-    "url": "https://github.com/dpaluy/claude-desktop-mcp/issues"
+    "url": "https://github.com/dpaluy/mcp-claude-desktop/issues"
   },
-  "homepage": "https://github.com/dpaluy/claude-desktop-mcp#readme",
+  "homepage": "https://github.com/dpaluy/mcp-claude-desktop#readme",
   "engines": {
     "node": ">=18"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 
 const server = new Server(
   {
-    name: 'claude-desktop-mcp',
+    name: 'mcp-claude-desktop',
     version: '0.1.0',
   },
   {
@@ -87,12 +87,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 async function main() {
-  logger.info('Starting Claude Desktop MCP Server...');
+  logger.info('Starting MCP Claude Desktop Server...');
   
   const transport = new StdioServerTransport();
   await server.connect(transport);
   
-  logger.info('Claude Desktop MCP Server started successfully');
+  logger.info('MCP Claude Desktop Server started successfully');
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
• Renamed package from `claude-desktop-mcp` to `mcp-claude-desktop`
• Updated all GitHub repository URLs to match new name
• Follows established MCP ecosystem naming convention (protocol-first)

## Changes
• **package.json**: Updated name, bin entry, and all repository URLs
• **README.md**: Updated title and all package/repository references
• **src/index.ts**: Updated server name and log messages

## Rationale
The new name `mcp-claude-desktop` aligns better with the Model Context Protocol ecosystem naming patterns, where most packages use the `mcp-*` prefix. This makes the package easier to discover and clearly identifies it as an MCP implementation.

## Test plan
- [x] Package builds successfully (`npm run build`)
- [x] All references updated consistently
- [ ] Package can be installed via npm after publishing
- [ ] MCP server starts with new name

🤖 Generated with [Claude Code](https://claude.ai/code)